### PR TITLE
Tensor parallelism support

### DIFF
--- a/analyze_cli.py
+++ b/analyze_cli.py
@@ -29,6 +29,12 @@ parser.add_argument("--kv_bit", type=int, default=16, help="kv cache bitwidth")
 parser.add_argument(
     "--use_flashattention", action="store_true", help="use flash attention"
 )
+parser.add_argument(
+    "--tp-size",
+    type=int,
+    default=1,
+    help="the number of devices for tensor parallelism to use"
+)
 args = parser.parse_args()
 
 analyzer = ModelAnalyzer(args.model_id, args.hardware, args.config_file,source=args.source)
@@ -39,5 +45,6 @@ results = analyzer.analyze(
     a_bit=args.a_bit,
     kv_bit=args.kv_bit,
     use_flashattention=args.use_flashattention,
+    tp_size=args.tp_size
 )
 analyzer.save_csv()

--- a/analyze_gen_cli.py
+++ b/analyze_gen_cli.py
@@ -20,11 +20,25 @@ parser.add_argument("--w_bit", type=int, default=16, help="weight bitwidth")
 parser.add_argument("--a_bit", type=int, default=16, help="temporary activation bitwidth")
 parser.add_argument("--kv_bit", type=int, default=16, help="kv cache bitwidth")
 parser.add_argument("--use_flashattention", action="store_true", help="use flash attention")
+parser.add_argument(
+    "--tp-size",
+    type=int,
+    default=1,
+    help="the number of devices for tensor parallelism to use"
+)
 args = parser.parse_args()
 
-
 analyzer=ModelAnalyzer(args.model_id,args.hardware,args.config_file)
-ret = analyzer.analyze_generate_task(args.promptlen, args.seqlen, args.batchsize, args.w_bit, args.a_bit, args.kv_bit, args.use_flashattention)
+ret = analyzer.analyze_generate_task(
+    args.promptlen,
+    args.seqlen,
+    args.batchsize,
+    args.w_bit,
+    args.a_bit,
+    args.kv_bit,
+    args.use_flashattention,
+    tp_size=args.tp_size
+)
 elapse = ret["inference_time"]
 prefill_elapse = ret["prefill_time"]
-print(f"{args.hardware}: 1st token latency {prefill_elapse}, total latency {elapse}, throughput {args.seqlen * args.batchsize / elapse} Token/sec")
+print(f"{args.hardware}: 1st token latency {prefill_elapse:.2f}, total latency {elapse:.2f}, throughput {args.seqlen * args.batchsize / elapse:.2f} Token/sec")

--- a/configs/Llama.py
+++ b/configs/Llama.py
@@ -2,10 +2,8 @@
 def get_num_attention_heads(model_params):
     return getattr(model_params, "num_attention_heads")
 
-
 def get_hidden_size(model_params):
     return getattr(model_params, "hidden_size")
-
 
 def get_num_key_value_heads(model_params):
     return getattr(model_params, "num_key_value_heads")
@@ -37,19 +35,25 @@ def post_process(model_params,args):
         })
     return layers
 
-def get_linear_layers(model_params):
+def get_linear_layers(model_params, tp_size: int):
     hidden_size=get_hidden_size(model_params)
     intermediate_size=get_intermediate_size(model_params)
     key_value_heads=get_num_key_value_heads(model_params)
     attention_heads=get_num_attention_heads(model_params)
+    
+    if tp_size > 1:
+        assert hidden_size % tp_size == 0
+        assert intermediate_size % tp_size == 0
+        assert key_value_heads % tp_size == 0
+    
     return {
-        "q_proj":[hidden_size, hidden_size],
-        "k_proj":[hidden_size, hidden_size*key_value_heads/attention_heads],
-        "v_proj":[hidden_size, hidden_size*key_value_heads/attention_heads],
-        "out_proj":[hidden_size, hidden_size],
-        "gate_proj":[hidden_size, intermediate_size],
-        "up_proj":[hidden_size,intermediate_size],
-        "down_proj":[intermediate_size, hidden_size],
+        "q_proj":[hidden_size, hidden_size // tp_size],
+        "k_proj":[hidden_size, hidden_size * key_value_heads // attention_heads // tp_size],
+        "v_proj":[hidden_size, hidden_size * key_value_heads // attention_heads // tp_size],
+        "out_proj":[hidden_size // tp_size, hidden_size],
+        "gate_proj":[hidden_size, intermediate_size // tp_size],
+        "up_proj":[hidden_size,intermediate_size // tp_size],
+        "down_proj":[intermediate_size // tp_size, hidden_size],
     }
 
 # name, input_names

--- a/configs/chatglm3.py
+++ b/configs/chatglm3.py
@@ -37,19 +37,25 @@ def post_process(model_params,args):
         })
     return layers
 
-def get_linear_layers(model_params):
+def get_linear_layers(model_params, tp_size: int):    
     hidden_size=get_hidden_size(model_params)
     intermediate_size=get_intermediate_size(model_params)
     key_value_heads=get_num_key_value_heads(model_params)
     attention_heads=get_num_attention_heads(model_params)
+    
+    if tp_size > 1:
+        assert hidden_size % tp_size == 0
+        assert intermediate_size % tp_size == 0
+        assert key_value_heads % tp_size == 0
+    
     return {
-        "q_proj":[hidden_size, hidden_size],
-        "k_proj":[hidden_size, hidden_size*key_value_heads/attention_heads],
-        "v_proj":[hidden_size, hidden_size*key_value_heads/attention_heads],
-        "out_proj":[hidden_size, hidden_size],
-        "gate_proj":[hidden_size, intermediate_size],
-        "up_proj":[hidden_size,intermediate_size],
-        "down_proj":[intermediate_size, hidden_size]
+        "q_proj": [hidden_size, hidden_size // tp_size],
+        "k_proj": [hidden_size, hidden_size * key_value_heads // attention_heads // tp_size],
+        "v_proj": [hidden_size, hidden_size * key_value_heads // attention_heads // tp_size],
+        "out_proj": [hidden_size // tp_size, hidden_size],
+        "gate_proj": [hidden_size, intermediate_size // tp_size],
+        "up_proj": [hidden_size, intermediate_size // tp_size],
+        "down_proj": [intermediate_size // tp_size, hidden_size]
     }
 
 from configs.Llama import flashattention_transformer_layer_graph,transformer_layer_graph

--- a/configs/gpt-j-6B.py
+++ b/configs/gpt-j-6B.py
@@ -37,19 +37,25 @@ def post_process(model_params,args):
         })
     return layers
 
-def get_linear_layers(model_params):
+def get_linear_layers(model_params, tp_size: int):    
     hidden_size=get_hidden_size(model_params)
     intermediate_size=get_intermediate_size(model_params)
     key_value_heads=get_num_key_value_heads(model_params)
     attention_heads=get_num_attention_heads(model_params)
+    
+    if tp_size > 1:
+        assert hidden_size % tp_size == 0
+        assert intermediate_size % tp_size == 0
+        assert key_value_heads % tp_size == 0
+    
     return {
-        "q_proj":[hidden_size, hidden_size],
-        "k_proj":[hidden_size, hidden_size*key_value_heads/attention_heads],
-        "v_proj":[hidden_size, hidden_size*key_value_heads/attention_heads],
-        "out_proj":[hidden_size, hidden_size],
+        "q_proj":[hidden_size, hidden_size // tp_size],
+        "k_proj":[hidden_size, hidden_size * key_value_heads // attention_heads // tp_size],
+        "v_proj":[hidden_size, hidden_size * key_value_heads // attention_heads // tp_size],
+        "out_proj":[hidden_size // tp_size, hidden_size],
         #"gate_proj":[hidden_size, intermediate_size],
-        "up_proj":[hidden_size,intermediate_size],
-        "down_proj":[intermediate_size, hidden_size],
+        "up_proj":[hidden_size, intermediate_size // tp_size],
+        "down_proj":[intermediate_size // tp_size, hidden_size],
     }
 
 # name, input_names

--- a/configs/opt.py
+++ b/configs/opt.py
@@ -38,19 +38,25 @@ def post_process(model_params,args):
         })
     return layers
 
-def get_linear_layers(model_params):
+def get_linear_layers(model_params, tp_size: int):    
     hidden_size = get_hidden_size(model_params)
     intermediate_size = get_intermediate_size(model_params)
     key_value_heads = get_num_key_value_heads(model_params)
     attention_heads = get_num_attention_heads(model_params)
+    
+    if tp_size > 1:
+        assert hidden_size % tp_size == 0
+        assert intermediate_size % tp_size == 0
+        assert key_value_heads % tp_size == 0
+    
     return {
-        "q_proj": [hidden_size, hidden_size],
-        "k_proj": [hidden_size, hidden_size * key_value_heads / attention_heads],
-        "v_proj": [hidden_size, hidden_size * key_value_heads / attention_heads],
-        "out_proj": [hidden_size, hidden_size],
-        "gate_proj": [hidden_size, intermediate_size],
-        "up_proj": [hidden_size, intermediate_size],
-        "down_proj": [intermediate_size, hidden_size],
+        "q_proj": [hidden_size, hidden_size // tp_size],
+        "k_proj": [hidden_size, hidden_size * key_value_heads // attention_heads // tp_size],
+        "v_proj": [hidden_size, hidden_size * key_value_heads // attention_heads // tp_size],
+        "out_proj": [hidden_size // tp_size, hidden_size],
+        "gate_proj": [hidden_size, intermediate_size // tp_size],
+        "up_proj": [hidden_size, intermediate_size // tp_size],
+        "down_proj": [intermediate_size // tp_size, hidden_size],
     }
 
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -28,6 +28,7 @@ const global_inference_config = ref({
   batch_size: 1, 
   seq_length: 1024, 
   gen_length: 1,
+  tp_size: 1,
   w_quant: "FP16", 
   a_quant: "FP16", 
   kv_quant: "FP16", 

--- a/frontend/src/components/left_controls/Config.vue
+++ b/frontend/src/components/left_controls/Config.vue
@@ -32,6 +32,15 @@
         <!-- <span id="seq_length">1024</span> -->
         <input type="number" v-model.lazy="gen_length" min="1" max="4096">
     </div>
+    <div class="config_div">
+        Tensor parallelism
+        <select v-model="tp_size">
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="4">4</option>
+            <option value="8">8</option>
+        </select>
+    </div>
     <!-- <div class="config_div">
         Generation Length:
         <input type="range" min="1" max="4096" value="1024" oninput="gen_length.innerText = this.value">
@@ -128,6 +137,7 @@ const inference_stage = ref('decode');
 const batch_size = ref(1);
 const seq_length = ref(1024);
 const gen_length = ref(1);
+const tp_size = ref(1);
 const w_quant = ref('FP16');
 const a_quant = ref('FP16');
 const kv_quant = ref('FP16');
@@ -148,6 +158,12 @@ watch(batch_size, (n) => {
 watch(seq_length, (n) => {
     console.log("seq_length", n)
     global_inference_config.value.seq_length = n
+    global_update_trigger.value += 1
+})
+
+watch(tp_size, (n) => {
+    console.log("tp_size", n)
+    global_inference_config.value.tp_size = n
     global_update_trigger.value += 1
 })
 

--- a/get_model_graph.py
+++ b/get_model_graph.py
@@ -55,6 +55,7 @@ def get_model_graph(model_id, hardware, config_path, inference_config):
     batch_size = int(inference_config["batch_size"])
     use_flashattention = bool(inference_config["use_flashattention"])
     gen_length = int(inference_config["gen_length"])
+    tp_size = int(inference_config["tp_size"])
 
     analyzer = get_analyer(model_id, hardware, config_path)
     result = analyzer.analyze(
@@ -64,6 +65,7 @@ def get_model_graph(model_id, hardware, config_path, inference_config):
         a_bit=a_bit,
         kv_bit=kv_bit,
         use_flashattention=use_flashattention,
+        tp_size=tp_size
     )
     bandwidth, max_OPS, onchip_buffer = analyzer.get_hardware_info()
     GQA = analyzer.get_model_info()["GQA"]

--- a/model_analyzer.py
+++ b/model_analyzer.py
@@ -36,7 +36,6 @@ class ModelAnalyzer:
         assert config_file is not None, "config file is not found, please specify it manually."
         print(f"use config file {config_file} for {model_id}")
         if source == "huggingface":
-            model_id = "/home/wangzhong/workspace/repos/LLM-Viewer/Meta-Llama-3.1-405B"
             self.model_params = AutoConfig.from_pretrained(model_id, trust_remote_code=True)
         else:
             if not os.path.exists(f"model_params/{source}.py"):
@@ -102,7 +101,7 @@ class ModelAnalyzer:
             with open(file_name, "a+") as f:
 
                 f.write(
-                    f"\n\n=== {self.model_id} {self.hardware} w_bit={self.w_bit} a_bit={self.a_bit} kv_bit={self.kv_bit} batchsize={self.batchsize} seqlen={self.seqlen}===\n"
+                    f"\n\n=== {self.model_id} {self.hardware} w_bit={self.w_bit} a_bit={self.a_bit} kv_bit={self.kv_bit} batchsize={self.batchsize} seqlen={self.seqlen} tp_size={self.tp_size} ===\n"
                 )
                 # legend
                 f.write(
@@ -185,6 +184,7 @@ class ModelAnalyzer:
         self.kv_bit = kv_bit
         self.batchsize = batchsize
         self.seqlen = seqlen
+        self.tp_size = tp_size
 
         w_byte = self.w_bit / 8
         a_byte = self.a_bit / 8


### PR DESCRIPTION
## analyze_gen_cli.py
```bash
python analyze_gen_cli.py Meta-Llama-3.1-405B nvidia_H100 --config_file configs/Llama.py --promptlen 32768 --seqlen 1 --w_bit 4 --a_bit 4 --kv_bit 4 --use_flashattention --tp-size 8
use config file configs/Llama.py for Meta-Llama-3.1-405B
nvidia_H100: 1st token latency 7.79, total latency 7.80, throughput 0.13 Token/sec
```

```bash
python analyze_gen_cli.py Meta-Llama-3.1-405B nvidia_H100 --config_file configs/Llama.py --promptlen 32768 --seqlen 1 --w_bit 4 --a_bit 4 --kv_bit 4 --use_flashattention --tp-size 1
use config file configs/Llama.py for Meta-Llama-3.1-405B
nvidia_H100: 1st token latency 19.42, total latency 19.49, throughput 0.05 Token/sec
```

## analyze_cli.py
```
=== Meta-Llama-3.1-405B nvidia_H100 w_bit=4 a_bit=4 kv_bit=4 batchsize=1 seqlen=32769 tp_size=8 ===
layer_name,OPs,Access,arithmetic_intensity,performance,bound,load_weight,load_act,store_act,load_kv_cache,store_kv_cache,inference_time
q_proj,67.1M,16.8MB,4.0,12.3T,memory,16.8MB,8.2KB,1.0KB,0.00B,0.00B,5.5us
k_proj,4.2M,1.1MB,4.0,12.2T,memory,1.0MB,8.2KB,0.00B,0.00B,64.0B,344.0ns
v_proj,4.2M,1.1MB,4.0,12.2T,memory,1.0MB,8.2KB,0.00B,0.00B,64.0B,344.0ns
out_proj,67.1M,16.8MB,4.0,12.3T,memory,16.8MB,1.0KB,8.2KB,0.00B,0.00B,5.5us
gate_proj,218M,54.5MB,4.0,12.3T,memory,54.5MB,8.2KB,3.3KB,0.00B,0.00B,17.8us
up_proj,218M,54.5MB,4.0,12.3T,memory,54.5MB,8.2KB,3.3KB,0.00B,0.00B,17.8us
down_proj,218M,54.5MB,4.0,12.3T,memory,54.5MB,3.3KB,8.2KB,0.00B,0.00B,17.8us
fused_attention,2.2G,37.8MB,57.4,176T,memory,0.00B,8.2KB,4.2MB,33.6MB,0.00B,12.3us
attn_norm,115K,16.4KB,7.0,21.5T,memory,0.00B,8.2KB,8.2KB,0.00B,0.00B,5.3ns
mlp_norm,115K,16.4KB,7.0,21.5T,memory,0.00B,8.2KB,8.2KB,0.00B,0.00B,5.3ns
attn_add,16.4K,16.4KB,1.0,3.1T,memory,0.00B,8.2KB,8.2KB,0.00B,0.00B,5.3ns
mlp_add,16.4K,16.4KB,1.0,3.1T,memory,0.00B,8.2KB,8.2KB,0.00B,0.00B,5.3ns
mlp_act,32.8K,24.6KB,1.3,4.1T,memory,0.00B,16.4KB,8.2KB,0.00B,0.00B,8.0ns
lm_head,2.1G,1.1GB,2.0,6.1T,memory,1.1GB,8.2KB,64.1KB,0.00B,0.00B,342.0us
```

```
=== Meta-Llama-3.1-405B nvidia_H100 w_bit=4 a_bit=4 kv_bit=4 batchsize=1 seqlen=32769 tp_size=1 ===
layer_name,OPs,Access,arithmetic_intensity,performance,bound,load_weight,load_act,store_act,load_kv_cache,store_kv_cache,inference_time
q_proj,537M,134MB,4.0,12.3T,memory,134MB,8.2KB,8.2KB,0.00B,0.00B,43.7us
k_proj,33.6M,8.4MB,4.0,12.3T,memory,8.4MB,8.2KB,0.00B,0.00B,512.0B,2.7us
v_proj,33.6M,8.4MB,4.0,12.3T,memory,8.4MB,8.2KB,0.00B,0.00B,512.0B,2.7us
out_proj,537M,134MB,4.0,12.3T,memory,134MB,8.2KB,8.2KB,0.00B,0.00B,43.7us
gate_proj,1.7G,436MB,4.0,12.3T,memory,436MB,8.2KB,26.6KB,0.00B,0.00B,142.0us
up_proj,1.7G,436MB,4.0,12.3T,memory,436MB,8.2KB,26.6KB,0.00B,0.00B,142.0us
down_proj,1.7G,436MB,4.0,12.3T,memory,436MB,26.6KB,8.2KB,0.00B,0.00B,142.0us
fused_attention,2.2G,37.8MB,57.4,176T,memory,0.00B,8.2KB,4.2MB,33.6MB,0.00B,12.3us
attn_norm,115K,16.4KB,7.0,21.5T,memory,0.00B,8.2KB,8.2KB,0.00B,0.00B,5.3ns
mlp_norm,115K,16.4KB,7.0,21.5T,memory,0.00B,8.2KB,8.2KB,0.00B,0.00B,5.3ns
attn_add,16.4K,16.4KB,1.0,3.1T,memory,0.00B,8.2KB,8.2KB,0.00B,0.00B,5.3ns
mlp_add,16.4K,16.4KB,1.0,3.1T,memory,0.00B,8.2KB,8.2KB,0.00B,0.00B,5.3ns
mlp_act,32.8K,24.6KB,1.3,4.1T,memory,0.00B,16.4KB,8.2KB,0.00B,0.00B,8.0ns
lm_head,2.1G,1.1GB,2.0,6.1T,memory,1.1GB,8.2KB,64.1KB,0.00B,0.00B,342.0us
```

## frontend
tp_size=8
![image](https://github.com/user-attachments/assets/b84673ae-9204-4eb1-abcd-18567d4edcd8)

tp_size=1
![image](https://github.com/user-attachments/assets/544567cb-3bad-4194-828f-36bcd7062071)
